### PR TITLE
Fixing bug: update outDir and rootDir configs for build output to be deployed

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && npm run copy-js",
     "copy-js": "node src/helpers/copy-js.js",
     "dev": "cross-env NODE_ENV=development nodemon src/server.ts",
-    "start": "cross-env NODE_ENV=production node src/dist/server.js",
+    "start": "cross-env NODE_ENV=production node dist/src/server.js",
     "test": "cross-env NODE_ENV=test jest --coverage",
     "lint": "eslint --ignore-path .eslintignore \"**/*.{js,ts}\"",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",

--- a/src/helpers/copy-js.js
+++ b/src/helpers/copy-js.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const sourceDir = 'src/database';
-const destDir = 'src/dist/database'; // Change the destination directory
+const destDir = 'dist/src/database'; // Change the destination directory
 
 // Function to recursively find JavaScript files in a directory
 function findJsFiles(dir) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
-    "rootDir": "./src" /* Specify the root folder within your source files. */,
+    "rootDir": "./" /* Specify the root folder within your source files. */,
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -55,7 +55,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./src/dist" /* Specify an output folder for all emitted files. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     "removeComments": true /* Disable emitting comments. */,
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
## Purpose

Adjusting TypeScript configuration to  ensures that the build output is consistent and follows the project structure. These changes simplify the build and deployment processes on render.

## Changes Made

I've changed these: 
- [x] outDir to './dist' in ts.config.json
- [x]  rootDir to './' in ts.config.json
- [x] destDir to 'dist/src/database' in copy-js.js

## Testing Instructions

None

## Related Issues

None

## Checklist

Please review the following checklist and make sure all tasks are complete before submitting:

- [x] Code follows the project's coding standards
- [x] Changes are covered by tests
- [x] Documentation is updated (if applicable)
- [x ] All tests pass
