### PR TITLE
ft-resend-verification-link

### DIFF
--- a/src/docs/users.yaml
+++ b/src/docs/users.yaml
@@ -162,3 +162,27 @@ paths:
           description: "Verification link has expired. Please request a new one."
         500:
           description: "Internal Server Error"
+
+  /api/users/resend-verify:
+    post:
+      summary: Endpoint for resend link to verify your email
+      tags:
+        - User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+      responses:
+        201:
+          description: Check your email to verify.
+        202:
+          description: User is already verified. Login to continue
+        400:
+          description: Email is already used, Login to continuue
+        500:
+          description: "Internal Server Error"

--- a/src/routes/userRoute.ts
+++ b/src/routes/userRoute.ts
@@ -7,6 +7,7 @@ import {
   editUserRole,
   getAllUser,
   getOneUser,
+  resendVerifyLink,
   signupUser,
   userVerify,
 } from '../controllers/userController';
@@ -22,6 +23,7 @@ router.delete('/:id', isAuthenticated, checkUserRoles('admin'), deleteUser);
 router.patch('/edit/:id', isAuthenticated, multerUpload.single('profileImage'), editUser); // remove id param
 router.put('/role/:userId', isAuthenticated, checkUserRoles('admin'), editUserRole);
 router.get('/:token/verify-email', userVerify);
+router.post('/resend-verify', resendVerifyLink);
 router.put('/deactivate/:userId', isAuthenticated, deactivateUserAccount);
 router.put('/activate/:userId', isAuthenticated, checkUserRoles('admin'), activateUserAccount);
 


### PR DESCRIPTION
## Purpose

The purpose of this update is to enhance the functionality of the user verification process by allowing the resendment of verification links in cases where the initially sent link has expired or has not been seen by the user.

## Changes Made

Several changes were made across the _user controller_, _user router_, and _users.yaml_ files to accommodate the resendment of verification links. These changes include modifications to the logic responsible for handling user verification requests and the generation of verification links.

## Testing Instructions

To test the updated functionality, please use Postman to send requests for verification link resendment. Verify that the resendment process works as expected, including handling expired or unseen verification links.

## Related Issues

Reference any related issues or pull requests

## Checklist

Please review the following checklist and make sure all tasks are complete before submitting:

- [ ] Code follows the project's coding standards
- [ ] Changes are covered by tests
- [ ] Documentation is updated (if applicable)
- [ ] All tests pass
